### PR TITLE
Changes introduced in 1.4.3 break non SASL authentication procedure.

### DIFF
--- a/src/JSJaCConnection.js
+++ b/src/JSJaCConnection.js
@@ -1105,7 +1105,7 @@ JSJaCConnection.prototype._parseStreamFeatures = function(doc) {
         this.oDbg.log("SASL detected",2);
     else {
         this.oDbg.log("No support for SASL detected",2);
-        return false;
+        return true;
     }
     
     /* [TODO]


### PR DESCRIPTION
Changes introduced in 1.4.3 break non SASL authentication procedure. Returning true as it was before seems to fix the problem. Sorry not had time to test deeper in code why exactly.
