### PR TITLE
Unicode JID

### DIFF
--- a/src/JSJaCConnection.js
+++ b/src/JSJaCConnection.js
@@ -830,7 +830,7 @@ JSJaCConnection.prototype._doSASLAuth = function() {
       this.username+String.fromCharCode(0)+
       this.pass;
       this.oDbg.log("authenticating with '"+authStr+"'",2);
-      authStr = btoa(authStr);
+      authStr = b64encode(authStr);
       return this._sendRaw("<auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='PLAIN'>"+authStr+"</auth>",
                            this._doSASLAuthDone);
     }
@@ -849,7 +849,7 @@ JSJaCConnection.prototype._doSASLAuthDigestMd5S1 = function(el) {
     this._handleEvent('onerror',JSJaCError('401','auth','not-authorized'));
     this.disconnect();
   } else {
-    var challenge = atob(el.firstChild.nodeValue);
+    var challenge = b64decode(el.firstChild.nodeValue);
     this.oDbg.log("got challenge: "+challenge,2);
     this._nonce = challenge.substring(challenge.indexOf("nonce=")+7);
     this._nonce = this._nonce.substring(0,this._nonce.indexOf("\""));
@@ -908,7 +908,7 @@ JSJaCConnection.prototype._doSASLAuthDigestMd5S2 = function(el) {
     return;
   }
 
-  var response = atob(el.firstChild.nodeValue);
+  var response = b64decode(el.firstChild.nodeValue);
   this.oDbg.log("response: "+response,2);
 
   var rspauth = response.substring(response.indexOf("rspauth=")+8);
@@ -960,7 +960,7 @@ JSJaCConnection.prototype._doFacebookAuth = function(el) {
     this._handleEvent('onerror',JSJaCError('401','auth','not-authorized'));
     this.disconnect();
   } else {
-    var challenge = atob(el.firstChild.nodeValue);
+    var challenge = b64decode(el.firstChild.nodeValue);
     this.oDbg.log("got challenge: "+challenge,2);
 	
 	//Let's split all the variables taked back from server side
@@ -1001,7 +1001,7 @@ JSJaCConnection.prototype._doFacebookAuth = function(el) {
 				   'v=' + response['v'] + '&' +
 				   'sig=' + response['sig'];
 
-		response = btoa(response);
+		response = b64encode(response);
 
 		return this._sendRaw("<response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>" + response + "</response>",
                            this._doFacebookAuthDone);

--- a/src/crypt.js
+++ b/src/crypt.js
@@ -625,14 +625,22 @@ if (typeof(atob) == 'undefined' || typeof(btoa) == 'undefined')
   b64arrays();
 
 if (typeof(atob) == 'undefined') {
-  atob = function(s) {
+  b64decode = function(s) {
     return utf8d2t(b64t2d(s));
+  }
+} else {
+  b64decode = function(s) {
+    return btoa(unescape(encodeURIComponent(s)));
   }
 }
 
 if (typeof(btoa) == 'undefined') {
-  btoa = function(s) {
+  b64encode = function(s) {
     return b64d2t(utf8t2d(s));
+  }
+} else {
+  b64encode = function(s) {
+    return decodeURIComponent(escape(atob(s)));
   }
 }
 


### PR DESCRIPTION
crypt.js will use browser's atob/btoa, if available. however, most of them don't work with unicode. a work-around has been mentioned on MDN, https://developer.mozilla.org/en/DOM/window.btoa#Unicode_Strings . This is my patch, hope it will work :-)
