### PR TITLE
Fix JSJaCIQ.errorReply() on IE9

### DIFF
--- a/src/JSJaCPacket.js
+++ b/src/JSJaCPacket.js
@@ -263,7 +263,7 @@ JSJaCPacket.prototype.errorReply = function(stanza_error) {
 
   rPacket.appendNode('error',
                      {code: stanza_error.code, type: stanza_error.type},
-                     [[stanza_error.cond]]);
+                     [[stanza_error.cond, {xmlns: NS_STANZAS}]]);
 
   return rPacket;
 };
@@ -411,7 +411,8 @@ JSJaCPacket.prototype.buildNode = function(elementName) {
   return JSJaCBuilder.buildNode(this.getDoc(),
                                 elementName,
                                 arguments[1],
-                                arguments[2]);
+                                arguments[2],
+                                arguments[3]);
 };
 
 /**
@@ -429,7 +430,6 @@ JSJaCPacket.prototype.appendNode = function(element) {
     return this.getNode().appendChild(this.buildNode(element,
                                                      arguments[1],
                                                      arguments[2],
-                                                     null,
                                                      this.getNode().namespaceURI));
   }
 };


### PR DESCRIPTION
JSJaCPacket.appendNode() is not passing current namespace to
buildNode() (due to missing argument, probably a typo) so every node
appended without namespace will end up with xmlns="" on IE9.

This causes a nice denial of service, since by default many clients
(including simpleclient from examples) will try to use errorReply on
unknown iq packets which will trigger this bug. So sending anyone on
IE9 random iq packet will cause that client to disconnect from server.

Fix it by correctly passing namespace to buildNode(). Additionally,
set proper namespace on error condition element.
