### PR TITLE
JsJacMessage GetNode

### DIFF
--- a/src/JSJaCPacket.js
+++ b/src/JSJaCPacket.js
@@ -56,6 +56,28 @@ JSJaCPacket.prototype.getNode = function() {
     return null;
 };
 
+
+
+/**
+ * Get the object in the node attributes. 
+ * @nodeName the node name  check buildNode
+ * @return {object}
+ *
+ */
+
+JSJaCPacket.prototype.getNodeVal = function(nodeName) {
+    var attributes_val = {}
+    if (!nodeName) return attributes_val;
+
+
+    Array.prototype.slice.call(this.getNode().getElementsByTagName(nodeName)[0].attributes).forEach(function(item) {
+        console.log(item.name + ': '+ item.value);
+        attributes_val[item.name] = item.value;
+    });
+
+    return attributes_val;
+}
+
 /**
  * Sets the 'to' attribute of the root node of this packet
  * @param {String} [to] A string representing a jid sending this packet to. If omitted the property will be deleted thus sending to service rather than dedicated recipient.


### PR DESCRIPTION
Hi, 

In JsjacMessage the node values is not possible to get from the client, this is a example.

Generate new node

``` javascript
    var customValues = {
        one:1,
        two:2
    }

    var oMsg = new JSJaCMessage();
    oMsg.buildNode("newNode");
    oMsg.appendNode("newNode",customValues);
    oMsg.setTo(new JSJaCJID(sendmessage));
    oMsg.setBody(sendtext);
    con.send(oMsg);
```

This is the xml:

``` xml
<message xmlns='jabber:client' to='test@192.168.100.68' from='eloy@192.168.100.68/17579aa1-0e71-4ca6-87e2-b6252d1cb3fb'><newNode one='1' two='2'/><body>hello</body></message></body>
```

In the other side of the customer, you only need use this to get all attributes:

``` javascript
function handleMessage(oJSJaCPacket) {
    var attrs = oJSJaCPacket.getNodeVal("newNode");
    ... 
}
```

Cheers
