### PR TITLE
Extensible Sasl Plain

### DIFF
--- a/src/JSJaCConnection.js
+++ b/src/JSJaCConnection.js
@@ -99,7 +99,7 @@ function JSJaCConnection(oArg) {
   /**
    * @private
    */
-   this._auhtorizationId = null;
+   this._authorizationId = null;
 }
 
 /**


### PR DESCRIPTION
Wanted to make it so the Sasl Plain string is able to be fully customized. this way user isn't restricted to only the string that JSJAC builds and can instead build whatever auth string their server desires.
