### PR TITLE
Move online check to the beginning of the method

### DIFF
--- a/src/JSJaCWebSocketConnection.js
+++ b/src/JSJaCWebSocketConnection.js
@@ -355,13 +355,13 @@ JSJaCWebSocketConnection.prototype._getInitialRequestString = function() {
 };
 
 JSJaCWebSocketConnection.prototype.send = function(packet, cb, arg) {
-  this._ws.onmessage = JSJaC.bind(this._onmessage, this);
-  if (!packet || !packet.pType) {
-    this.oDbg.log('no packet: ' + packet, 1);
+  if (!this.connected()) {
     return false;
   }
 
-  if (!this.connected()) {
+  this._ws.onmessage = JSJaC.bind(this._onmessage, this);
+  if (!packet || !packet.pType) {
+    this.oDbg.log('no packet: ' + packet, 1);
     return false;
   }
 

--- a/src/JSJaCWebSocketConnection.js
+++ b/src/JSJaCWebSocketConnection.js
@@ -359,11 +359,12 @@ JSJaCWebSocketConnection.prototype.send = function(packet, cb, arg) {
     return false;
   }
 
-  this._ws.onmessage = JSJaC.bind(this._onmessage, this);
   if (!packet || !packet.pType) {
     this.oDbg.log('no packet: ' + packet, 1);
     return false;
   }
+
+  this._ws.onmessage = JSJaC.bind(this._onmessage, this);
 
   // remember id for response if callback present
   if (cb) {


### PR DESCRIPTION
If we're not _ws connected, this._ws is null and the binding raises an
exception. Just noticed that on device resume when a ping timer was 
running without checking for the online status.